### PR TITLE
Fix for crash when a user is not found

### DIFF
--- a/convert_jira_to_spira_issues.py
+++ b/convert_jira_to_spira_issues.py
@@ -343,7 +343,7 @@ def convert_jira_to_spira_issues(
 
 def find_spira_user_id_by_email(users, person_field, issue):
     if not issue["fields"][person_field]:
-        return None
+        return 1
     else:
         user = next(
             filter(
@@ -357,7 +357,7 @@ def find_spira_user_id_by_email(users, person_field, issue):
     if user:
         return user["UserId"]
     else:
-        return None
+        return 1
 
 
 def calculate_estimate_points(aggregatetimeoriginalestimate: int | None):


### PR DESCRIPTION
When migrating a issue the script tries to match the email address of the Jira user to a user in Spira. When this user does not exist the script has tried to set the CreatorId of the artifact to a null value.

While migrating some issues where the user did not exist we found that Spira requires the CreatorId to be an Integer. Because of this the script crashed. To remedy this, when not finding a user for a specific issue, this fix will instead set the CreatorId to integer value 1, the system admin user. This makes it so the issue can be migrated, the script not crashing, and the correct user can be set in the GUI or otherwise later.

In the future the plan is to match the user by their username first and the email as a secondary fallback, but this is a fix for making it work right now. Another alternative that is explored is also being able to set the fallback user in the template file, but not in this fix.

